### PR TITLE
Support arbitrary camera roll

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.0-SNAPSHOT'
+    id 'fabric-loom' version '1.1-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.12-SNAPSHOT'
+    id 'fabric-loom' version '1.0-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -34,7 +34,7 @@ processResources {
 // ensure that the encoding is set to UTF-8, no matter what the system default is
 // this fixes some edge cases with special characters not displaying correctly
 // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.encoding = "UTF-8"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,21 +1,22 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
+org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
 # After making changes
 # gradlew --refresh-dependencies
 # To remap the mixin locations:
-# gradlew migrateMappings --mappings "1.16.1+build.9"
+# gradlew migrateMappings --mappings "1.19.3+build.5"
 
-minecraft_version=1.19
-yarn_mappings=1.19+build.1
-loader_version=0.14.7
+minecraft_version=1.19.3
+yarn_mappings=1.19.3+build.5
+loader_version=0.14.13
 
 #Fabric api
-fabric_version=0.55.3+1.19
+fabric_version=0.71.0+1.19.3
 
 # Mod Properties
-mod_version = 1.19-fabric-1
+mod_version = 1.19.3-fabric-1
 maven_group = net.torocraft
 archives_base_name = flighthud

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,6 @@ loader_version=0.14.18
 fabric_version=0.76.0+1.19.4
 
 # Mod Properties
-mod_version = 1.19.4-fabric-1
+mod_version = 1.19.4-fabric-2
 maven_group = net.torocraft
 archives_base_name = flighthud

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,14 +9,14 @@ org.gradle.parallel=true
 # To remap the mixin locations:
 # gradlew migrateMappings --mappings "1.19.3+build.5"
 
-minecraft_version=1.19.3
-yarn_mappings=1.19.3+build.5
-loader_version=0.14.13
+minecraft_version=1.19.4
+yarn_mappings=1.19.4+build.1
+loader_version=0.14.18
 
 #Fabric api
-fabric_version=0.71.0+1.19.3
+fabric_version=0.76.0+1.19.4
 
 # Mod Properties
-mod_version = 1.19.3-fabric-1
+mod_version = 1.19.4-fabric-1
 maven_group = net.torocraft
 archives_base_name = flighthud

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/torocraft/flighthud/FlightHud.java
+++ b/src/main/java/net/torocraft/flighthud/FlightHud.java
@@ -38,6 +38,8 @@ public class FlightHud implements ClientModInitializer {
 
   private static KeyBinding keyBinding;
 
+  public static final FlightComputer computer = new FlightComputer();
+
   @Override
   public void onInitializeClient() {
     CONFIG_LOADER_SETTINGS.load();

--- a/src/main/java/net/torocraft/flighthud/HudComponent.java
+++ b/src/main/java/net/torocraft/flighthud/HudComponent.java
@@ -3,16 +3,11 @@ package net.torocraft.flighthud;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawableHelper;
-import net.minecraft.client.render.BufferBuilder;
-import net.minecraft.client.render.BufferRenderer;
-import net.minecraft.client.render.GameRenderer;
-import net.minecraft.client.render.Tessellator;
-import net.minecraft.client.render.VertexFormats;
-import net.minecraft.client.render.VertexFormat;
+import net.minecraft.client.render.*;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.util.math.Vec3f;
-import net.minecraft.util.math.Matrix4f;
+import net.minecraft.util.math.RotationAxis;
 import net.torocraft.flighthud.config.HudConfig;
+import org.joml.Matrix4f;
 
 public abstract class HudComponent extends DrawableHelper {
 
@@ -27,7 +22,8 @@ public abstract class HudComponent extends DrawableHelper {
   protected void drawPointer(MatrixStack m, float x, float y, float rot) {
     m.push();
     m.translate(x, y, 0);
-    m.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(rot + 45));
+    m.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(rot + 45));
+//    m.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(rot + 45));
     drawVerticalLine(m, 0, 0, 5, CONFIG.color);
     drawHorizontalLine(m, 0, 5, 0, CONFIG.color);
     m.pop();
@@ -131,13 +127,13 @@ public abstract class HudComponent extends DrawableHelper {
     RenderSystem.enableBlend();
     RenderSystem.disableTexture();
     RenderSystem.defaultBlendFunc();
-    RenderSystem.setShader(GameRenderer::getPositionColorShader);
+    RenderSystem.setShader(GameRenderer::getPositionColorProgram);
     bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR);
     bufferBuilder.vertex(matrix, x1, y2, 0.0F).color(r, g, b, alpha).next();
     bufferBuilder.vertex(matrix, x2, y2, 0.0F).color(r, g, b, alpha).next();
     bufferBuilder.vertex(matrix, x2, y1, 0.0F).color(r, g, b, alpha).next();
     bufferBuilder.vertex(matrix, x1, y1, 0.0F).color(r, g, b, alpha).next();
-    BufferRenderer.drawWithShader(bufferBuilder.end());
+    BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
     RenderSystem.enableTexture();
     RenderSystem.disableBlend();
   }

--- a/src/main/java/net/torocraft/flighthud/HudComponent.java
+++ b/src/main/java/net/torocraft/flighthud/HudComponent.java
@@ -125,7 +125,6 @@ public abstract class HudComponent extends DrawableHelper {
     float b = (float) (color & 255) / 255.0F;
     BufferBuilder bufferBuilder = Tessellator.getInstance().getBuffer();
     RenderSystem.enableBlend();
-    RenderSystem.disableTexture();
     RenderSystem.defaultBlendFunc();
     RenderSystem.setShader(GameRenderer::getPositionColorProgram);
     bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR);
@@ -134,7 +133,6 @@ public abstract class HudComponent extends DrawableHelper {
     bufferBuilder.vertex(matrix, x2, y1, 0.0F).color(r, g, b, alpha).next();
     bufferBuilder.vertex(matrix, x1, y1, 0.0F).color(r, g, b, alpha).next();
     BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
-    RenderSystem.enableTexture();
     RenderSystem.disableBlend();
   }
 }

--- a/src/main/java/net/torocraft/flighthud/HudRenderer.java
+++ b/src/main/java/net/torocraft/flighthud/HudRenderer.java
@@ -1,5 +1,6 @@
 package net.torocraft.flighthud;
 
+import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.util.math.MatrixStack;
 import net.torocraft.flighthud.components.AltitudeIndicator;
@@ -11,10 +12,11 @@ import net.torocraft.flighthud.components.PitchIndicator;
 import net.torocraft.flighthud.components.SpeedIndicator;
 import net.torocraft.flighthud.config.SettingsConfig.DisplayMode;
 
+import static net.torocraft.flighthud.FlightHud.computer;
+
 public class HudRenderer extends HudComponent {
 
   private final Dimensions dim = new Dimensions();
-  private final FlightComputer computer = new FlightComputer();
   private static final String FULL = DisplayMode.FULL.toString();
   private static final String MIN = DisplayMode.MIN.toString();
 
@@ -57,7 +59,6 @@ public class HudRenderer extends HudComponent {
         m.scale(scale, scale, scale);
       }
 
-      computer.update(client, partial);
       dim.update(client);
 
       for (HudComponent component : components) {

--- a/src/main/java/net/torocraft/flighthud/components/PitchIndicator.java
+++ b/src/main/java/net/torocraft/flighthud/components/PitchIndicator.java
@@ -2,142 +2,143 @@ package net.torocraft.flighthud.components;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.util.math.Vec3f;
+import net.minecraft.util.math.RotationAxis;
 import net.torocraft.flighthud.Dimensions;
 import net.torocraft.flighthud.FlightComputer;
 import net.torocraft.flighthud.HudComponent;
 
 public class PitchIndicator extends HudComponent {
-  private final Dimensions dim;
-  private final FlightComputer computer;
-  private final PitchIndicatorData pitchData = new PitchIndicatorData();
+    private final Dimensions dim;
+    private final FlightComputer computer;
+    private final PitchIndicatorData pitchData = new PitchIndicatorData();
 
-  public PitchIndicator(FlightComputer computer, Dimensions dim) {
-    this.computer = computer;
-    this.dim = dim;
-  }
-
-  @Override
-  public void render(MatrixStack m, float partial, MinecraftClient mc) {
-    pitchData.update(dim);
-
-    float horizonOffset = computer.pitch * dim.degreesPerPixel;
-    float yHorizon = dim.yMid + horizonOffset;
-
-    float a = dim.yMid;
-    float b = dim.xMid;
-
-    float roll = computer.roll * (CONFIG.pitchLadder_reverseRoll ? -1 : 1);
-
-    if (CONFIG.pitchLadder_showRoll) {
-      m.push();
-      m.translate(b, a, 0);
-      m.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(roll));
-      m.translate(-b, -a, 0);
+    public PitchIndicator(FlightComputer computer, Dimensions dim) {
+        this.computer = computer;
+        this.dim = dim;
     }
 
-    if (CONFIG.pitchLadder_showLadder) {
-      drawLadder(mc, m, yHorizon);
+    @Override
+    public void render(MatrixStack m, float partial, MinecraftClient mc) {
+        pitchData.update(dim);
+
+        float horizonOffset = computer.pitch * dim.degreesPerPixel;
+        float yHorizon = dim.yMid + horizonOffset;
+
+        float a = dim.yMid;
+        float b = dim.xMid;
+
+        float roll = computer.roll * (CONFIG.pitchLadder_reverseRoll ? -1 : 1);
+
+        if (CONFIG.pitchLadder_showRoll) {
+            m.push();
+            m.translate(b, a, 0);
+            m.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(roll));
+            //m.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(roll));
+            m.translate(-b, -a, 0);
+        }
+
+        if (CONFIG.pitchLadder_showLadder) {
+            drawLadder(mc, m, yHorizon);
+        }
+
+        drawReferenceMark(mc, m, yHorizon, CONFIG.pitchLadder_optimumClimbAngle);
+        drawReferenceMark(mc, m, yHorizon, CONFIG.pitchLadder_optimumGlideAngle);
+
+        if (CONFIG.pitchLadder_showHorizon) {
+            pitchData.l1 -= pitchData.margin;
+            pitchData.r2 += pitchData.margin;
+            drawDegreeBar(mc, m, 0, yHorizon);
+        }
+
+        if (CONFIG.pitchLadder_showRoll) {
+            m.pop();
+        }
     }
 
-    drawReferenceMark(mc, m, yHorizon, CONFIG.pitchLadder_optimumClimbAngle);
-    drawReferenceMark(mc, m, yHorizon, CONFIG.pitchLadder_optimumGlideAngle);
+    private void drawLadder(MinecraftClient mc, MatrixStack m, float yHorizon) {
+        int degreesPerBar = CONFIG.pitchLadder_degreesPerBar;
 
-    if (CONFIG.pitchLadder_showHorizon) {
-      pitchData.l1 -= pitchData.margin;
-      pitchData.r2 += pitchData.margin;
-      drawDegreeBar(mc, m, 0, yHorizon);
+        if (degreesPerBar < 1) {
+            degreesPerBar = 20;
+        }
+
+        for (int i = degreesPerBar; i <= 90; i = i + degreesPerBar) {
+            float offset = dim.degreesPerPixel * i;
+            drawDegreeBar(mc, m, -i, yHorizon + offset);
+            drawDegreeBar(mc, m, i, yHorizon - offset);
+        }
+
     }
 
-    if (CONFIG.pitchLadder_showRoll) {
-      m.pop();
-    }
-  }
+    private void drawReferenceMark(MinecraftClient mc, MatrixStack m, float yHorizon, float degrees) {
+        if (degrees == 0) {
+            return;
+        }
 
-  private void drawLadder(MinecraftClient mc, MatrixStack m, float yHorizon) {
-    int degreesPerBar = CONFIG.pitchLadder_degreesPerBar;
+        float y = (-degrees * dim.degreesPerPixel) + yHorizon;
 
-    if (degreesPerBar < 1) {
-      degreesPerBar = 20;
-    }
+        if (y < dim.tFrame || y > dim.bFrame) {
+            return;
+        }
 
-    for (int i = degreesPerBar; i <= 90; i = i + degreesPerBar) {
-      float offset = dim.degreesPerPixel * i;
-      drawDegreeBar(mc, m, -i, yHorizon + offset);
-      drawDegreeBar(mc, m, i, yHorizon - offset);
-    }
+        float width = (pitchData.l2 - pitchData.l1) * 0.45f;
+        float l1 = pitchData.l2 - width;
+        float r2 = pitchData.r1 + width;
 
-  }
-
-  private void drawReferenceMark(MinecraftClient mc, MatrixStack m, float yHorizon, float degrees) {
-    if (degrees == 0) {
-      return;
+        drawHorizontalLineDashed(m, l1, pitchData.l2, y, 3);
+        drawHorizontalLineDashed(m, pitchData.r1, r2, y, 3);
     }
 
-    float y = (-degrees * dim.degreesPerPixel) + yHorizon;
+    private void drawDegreeBar(MinecraftClient mc, MatrixStack m, float degree, float y) {
 
-    if (y < dim.tFrame || y > dim.bFrame) {
-      return;
+        if (y < dim.tFrame || y > dim.bFrame) {
+            return;
+        }
+
+        int dashes = degree < 0 ? 4 : 1;
+
+        drawHorizontalLineDashed(m, pitchData.l1, pitchData.l2, y, dashes);
+        drawHorizontalLineDashed(m, pitchData.r1, pitchData.r2, y, dashes);
+
+        int sideTickHeight = degree >= 0 ? 5 : -5;
+        drawVerticalLine(m, pitchData.l1, y, y + sideTickHeight);
+        drawVerticalLine(m, pitchData.r2, y, y + sideTickHeight);
+
+        int fontVerticalOffset = degree >= 0 ? 0 : 6;
+
+        drawFont(mc, m, String.format("%d", i(Math.abs(degree))), pitchData.r2 + 6,
+                (float) y - fontVerticalOffset);
+
+        drawFont(mc, m, String.format("%d", i(Math.abs(degree))), pitchData.l1 - 17,
+                (float) y - fontVerticalOffset);
     }
 
-    float width = (pitchData.l2 - pitchData.l1) * 0.45f;
-    float l1 = pitchData.l2 - width;
-    float r2 = pitchData.r1 + width;
+    private static class PitchIndicatorData {
+        public float width;
+        public float mid;
+        public float margin;
+        public float sideWidth;
+        public float l1;
+        public float l2;
+        public float r1;
+        public float r2;
 
-    drawHorizontalLineDashed(m, l1, pitchData.l2, y, 3);
-    drawHorizontalLineDashed(m, pitchData.r1, r2, y, 3);
-  }
+        public void update(Dimensions dim) {
+            width = i(dim.wScreen / 3);
+            float left = width;
 
-  private void drawDegreeBar(MinecraftClient mc, MatrixStack m, float degree, float y) {
+            mid = i((width / 2) + left);
+            margin = i(width * 0.3d);
+            l1 = left + margin;
+            l2 = mid - 7;
+            sideWidth = l2 - l1;
+            r1 = mid + 8;
+            r2 = r1 + sideWidth;
+        }
 
-    if (y < dim.tFrame || y > dim.bFrame) {
-      return;
+        private int i(double d) {
+            return (int) Math.round(d);
+        }
     }
-
-    int dashes = degree < 0 ? 4 : 1;
-
-    drawHorizontalLineDashed(m, pitchData.l1, pitchData.l2, y, dashes);
-    drawHorizontalLineDashed(m, pitchData.r1, pitchData.r2, y, dashes);
-
-    int sideTickHeight = degree >= 0 ? 5 : -5;
-    drawVerticalLine(m, pitchData.l1, y, y + sideTickHeight);
-    drawVerticalLine(m, pitchData.r2, y, y + sideTickHeight);
-
-    int fontVerticalOffset = degree >= 0 ? 0 : 6;
-
-    drawFont(mc, m, String.format("%d", i(Math.abs(degree))), pitchData.r2 + 6,
-        (float) y - fontVerticalOffset);
-
-    drawFont(mc, m, String.format("%d", i(Math.abs(degree))), pitchData.l1 - 17,
-        (float) y - fontVerticalOffset);
-  }
-
-  private static class PitchIndicatorData {
-    public float width;
-    public float mid;
-    public float margin;
-    public float sideWidth;
-    public float l1;
-    public float l2;
-    public float r1;
-    public float r2;
-
-    public void update(Dimensions dim) {
-      width = i(dim.wScreen / 3);
-      float left = width;
-
-      mid = i((width / 2) + left);
-      margin = i(width * 0.3d);
-      l1 = left + margin;
-      l2 = mid - 7;
-      sideWidth = l2 - l1;
-      r1 = mid + 8;
-      r2 = r1 + sideWidth;
-    }
-
-    private int i(double d) {
-      return (int) Math.round(d);
-    }
-  }
 
 }

--- a/src/main/java/net/torocraft/flighthud/config/SettingsConfig.java
+++ b/src/main/java/net/torocraft/flighthud/config/SettingsConfig.java
@@ -14,8 +14,6 @@ public class SettingsConfig implements IConfig {
   public String displayModeWhenFlying = DisplayMode.FULL.toString();
   public String displayModeWhenNotFlying = DisplayMode.NONE.toString();
   public boolean calculateRoll = true;
-  public float rollTurningForce = 1.25f;
-  public float rollSmoothing = 0.85f;
 
   @Override
   public void update() {

--- a/src/main/java/net/torocraft/flighthud/mixin/GameRendererMixin.java
+++ b/src/main/java/net/torocraft/flighthud/mixin/GameRendererMixin.java
@@ -1,0 +1,40 @@
+package net.torocraft.flighthud.mixin;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.GameRenderer;
+import net.minecraft.client.util.math.MatrixStack;
+import org.joml.Matrix3f;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static net.torocraft.flighthud.FlightHud.computer;
+
+@Mixin(GameRenderer.class)
+public class GameRendererMixin {
+    @Shadow
+    @Final
+    MinecraftClient client;
+
+    @Inject(
+            method = "renderWorld",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcom/mojang/blaze3d/systems/RenderSystem;setInverseViewRotationMatrix(Lorg/joml/Matrix3f;)V",
+                    shift = At.Shift.AFTER
+            )
+    )
+    private void renderWorld(
+            float tickDelta,
+            long limitTime,
+            MatrixStack matrices,
+            CallbackInfo ci
+    ) {
+        Matrix3f inverseViewRotationMatrix = RenderSystem.getInverseViewRotationMatrix();
+        computer.update(client, inverseViewRotationMatrix.invert());
+    }
+}

--- a/src/main/java/net/torocraft/flighthud/mixin/InGameHudMixin.java
+++ b/src/main/java/net/torocraft/flighthud/mixin/InGameHudMixin.java
@@ -16,14 +16,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class InGameHudMixin {
 
   @Unique
-  private final HudRenderer hud = new HudRenderer();
+  private final HudRenderer hudRenderer = new HudRenderer();
 
   @Final
   @Shadow
   private MinecraftClient client;
 
   @Inject(method = "render", at = @At("RETURN"))
-  private void render(MatrixStack ms, float partial, CallbackInfo info) {
-    hud.render(ms, partial, client);
+  private void render(MatrixStack ms, float tickDelta, CallbackInfo info) {
+    hudRenderer.render(ms, tickDelta, client);
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,9 +24,9 @@
     "flighthud.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.14.11",
+    "fabricloader": ">=0.14.18",
     "fabric-api": "*",
-    "minecraft": "~1.19.3",
+    "minecraft": "~1.19.4",
     "java": ">=17"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,9 +24,9 @@
     "flighthud.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.14.7",
-    "fabric": "*",
-    "minecraft": ">=1.19",
+    "fabricloader": ">=0.14.11",
+    "fabric-api": "*",
+    "minecraft": "~1.19.3",
     "java": ">=17"
   }
 }

--- a/src/main/resources/flighthud.mixins.json
+++ b/src/main/resources/flighthud.mixins.json
@@ -4,7 +4,8 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [],
   "client": [
-    "InGameHudMixin"
+    "InGameHudMixin",
+    "GameRendererMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Based on #18. Thanks for fixing support for 1.19.4 @end-user!

---

Switch to use whatever camera orientation is used in `GameRenderer#renderWorld`. Fetches the `InverseViewRotationMatrix` used just before world rendering occurs and computes roll from that.

This enables roll support for mods [_Cool Elytra Roll_](https://www.curseforge.com/minecraft/mc-mods/cool-elytra-roll) and [_Do a Barrel Roll_](https://www.curseforge.com/minecraft/mc-mods/do-a-barrel-roll), and implicitly supports any other mod which changes camera orientation.

Also moves the `FlightComputer` instance to be `public static final FlightHud#computer`, since both `InGameHudMixin` and `GameRendererMixin` need access and it seems a good place to put the singleton.

---

Short demo clip, showing a full flip with _Do a Barrel Roll_, here: https://youtu.be/V4x2M-dlUL0